### PR TITLE
Allow a Comments table

### DIFF
--- a/rflint/rules/suiteRules.py
+++ b/rflint/rules/suiteRules.py
@@ -24,7 +24,7 @@ class InvalidTable(SuiteRule):
 
     def apply(self, suite):
         for table in suite.tables:
-            if (not re.match(r'^(settings?|metadata|(test )?cases?|(user )?keywords?|variables?)$', 
+            if (not re.match(r'^(comments?|settings?|metadata|(test )?cases?|(user )?keywords?|variables?)$', 
                              table.name, re.IGNORECASE)):
                 self.report(suite, "Unknown table name '%s'" % table.name, table.linenumber)
 

--- a/test_data/acceptance/rules/InvalidTable_Data.robot
+++ b/test_data/acceptance/rules/InvalidTable_Data.robot
@@ -19,6 +19,8 @@
   *** Setting ***
 *** Setting ***
 *** Settings ***
+*** Comment ***
+*** Comments ***
 *** Metadata ***
 *** Test Case ***
 *** Test Cases ***
@@ -32,6 +34,5 @@
 # these should fail the rule
 
 *** bogus ***
-*** Comments ***
 
 

--- a/tests/acceptance/rules/InvalidTable.robot
+++ b/tests/acceptance/rules/InvalidTable.robot
@@ -19,8 +19,8 @@
 | | ... | --error  | InvalidTable
 | | ... | test_data/acceptance/rules/InvalidTable_Data.robot
 | |
-| | rflint return code should be | 7
-| | rflint should report 7 errors
+| | rflint return code should be | 6
+| | rflint should report 6 errors
 | | rflint should report 0 warnings
 
 | Verify that the proper error message is returned
@@ -40,5 +40,4 @@
 | | ... | E: 8, 0: Unknown table name '' (InvalidTable)
 | | ... | E: 9, 0: Unknown table name 'Testcase' (InvalidTable)
 | | ... | E: 10, 0: Unknown table name 'Key word' (InvalidTable)
-| | ... | E: 34, 0: Unknown table name 'bogus' (InvalidTable)
-| | ... | E: 35, 0: Unknown table name 'Comments' (InvalidTable)
+| | ... | E: 36, 0: Unknown table name 'bogus' (InvalidTable)


### PR DESCRIPTION
'Comments' (or 'Comment') is a valid table name:
http://robotframework.org/robotframework/3.1.2/RobotFrameworkUserGuide.html#test-data-sections

'User Keywords' is also deprecated (should drop the 'User'), but is valid in older robot; maybe you'll want to warn for it.