### PR TITLE
Report non existent file

### DIFF
--- a/rflint/parser/parser.py
+++ b/rflint/parser/parser.py
@@ -126,10 +126,7 @@ class RobotFile(object):
         self.tables = []
         self.rows = []
 
-        try:
-            self._load(path)
-        except Exception as e:
-            sys.stderr.write("there was a problem reading '%s': %s\n" % (path, str(e)))
+        self._load(path)
 
     def walk(self, *types):
         '''

--- a/rflint/rflint.py
+++ b/rflint/rflint.py
@@ -103,9 +103,6 @@ class RfLint(object):
         self.counts = { ERROR: 0, WARNING: 0, "other": 0}
 
         for filename in self.args.args:
-            if not (os.path.exists(filename)):
-                sys.stderr.write("rflint: %s: No such file or directory\n" % filename)
-                continue
             if os.path.isdir(filename):
                 self._process_folder(filename)
             else:
@@ -154,7 +151,12 @@ class RfLint(object):
         # we process the next file.
         self._print_filename = filename if self.args.print_filenames else None
 
-        robot_file = RobotFactory(filename)
+        try:
+            robot_file = RobotFactory(filename)
+        except Exception as e:
+            self.report(filename=filename, rulename="RfLint",
+                        message=str(e), severity=ERROR, linenumber=0, char=0)
+
         for rule in self.general_rules:
             if rule.severity != IGNORE:
                 rule.apply(robot_file)

--- a/tests/acceptance/rules/NonExistentFile.robot
+++ b/tests/acceptance/rules/NonExistentFile.robot
@@ -1,0 +1,42 @@
+*** Settings ***
+| Documentation | Tests for the rule 'InvalidTable'
+| Resource      | ../SharedKeywords.robot
+|
+| Test Teardown
+| ... | Run keyword if | "${TEST STATUS}" == "FAIL"
+| ... | log | ${result.stdout}\n${result.stderr}
+
+*** Test Cases ***
+| Report an error on non-existent file
+| | [Documentation]
+| | ... | Check an error is raised when specifying a file that
+| | ... | does not exist
+| |
+| | [Setup] | Run rf-lint with the following options:
+| | ... | test_data/does/not/exist.robot
+| |
+| | rflint return code should be | 1
+| | rflint should report 1 errors
+| | rflint should report 0 warnings
+| |
+| | Output should contain
+| | ... | + test_data/does/not/exist.robot
+| | ... | E: 0, 0: * No such file or directory* (RfLint)
+
+| Report an error on non-existent file with custom format
+| | [Documentation]
+| | ... | Check an error is raised when specifying a file that
+| | ... | does not exist, and that the error message is formatted
+| | ... | according to custom rule
+| |
+| | [Setup] | Run rf-lint with the following options:
+| | ... | --no-filename
+| | ... | --format={severity}: {filename}:{linenumber}: {message}
+| | ... | test_data/does/not/exist.robot
+| |
+| | rflint return code should be | 1
+| | rflint should report 1 errors
+| | rflint should report 0 warnings
+| |
+| | Output should contain
+| | ... | E: test_data/does/not/exist.robot:0: * No such file or directory*

--- a/tests/acceptance/rules/TooManyTestCases.robot
+++ b/tests/acceptance/rules/TooManyTestCases.robot
@@ -48,7 +48,7 @@
 | | ... | --no-filename
 | | ... | --ignore | all
 | | ... | --error  | TooManyTestCases
-| | ... | ${SUITE SOURCE} | use this file as input
+| | ... | ${SUITE SOURCE}
 | |
 | | rflint return code should be | 0
 | | rflint should report 0 errors

--- a/tests/acceptance/rules/TooManyTestSteps.robot
+++ b/tests/acceptance/rules/TooManyTestSteps.robot
@@ -15,7 +15,7 @@
 | | ... | --no-filename
 | | ... | --ignore | all
 | | ... | --error  | TooManyTestSteps
-| | ... | ${SUITE SOURCE} | use this file as input
+| | ... | ${SUITE SOURCE}
 | |
 | | No operation
 | | No operation

--- a/tests/acceptance/self-test.robot
+++ b/tests/acceptance/self-test.robot
@@ -24,7 +24,6 @@
 | tests/acceptance/rules/TooManyTestSteps.robot          | 0
 | tests/acceptance/rules/LineTooLong.robot               | 0
 | tests/acceptance/rules/FileTooLong.robot               | 0
-| tests/acceptance/rules/TrailingBlankLines.robot        | 0
 
 *** Keywords ***
 | Run rflint and verify there are no errors or warnings


### PR DESCRIPTION
Hi Bryan,

Currently rflint doesn't report an error when run on a non-existent file, or a file it can't open for some other reason, only giving a message on stderr. This changes that behaviour, by going through RfLint.report to report the error. As a result the error message is formatted according to the `--format` option and update the exit code.