### PR TITLE
Update table names for Robot3

### DIFF
--- a/rflint/rules/resourceRules.py
+++ b/rflint/rules/resourceRules.py
@@ -1,0 +1,28 @@
+import re
+
+from rflint.common import ResourceRule
+
+class InvalidTableInResource(ResourceRule):
+    '''Verify that there are no invalid table headers'''
+    valid_tables_re = None
+    default_robot_level = "robot3"
+
+    def configure(self, robot_level):
+        valid_tables = ['comments?', 'settings?', 'keywords?', 'variables?']
+        if robot_level == "robot2":
+            valid_tables += ['metadata', 'user keywords?']
+        self.valid_tables_re = re.compile('^(' + '|'.join(valid_tables) + ')$',
+                                          re.I)
+
+        if robot_level == "robot2":
+            valid_tables += ['metadata', 'user keyword']
+        self.valid_tables_re = re.compile('^(' + '|'.join(valid_tables) + ')$',
+                                          re.I)
+
+    def apply(self, resource):
+        if not self.valid_tables_re:
+            self.configure(self.default_robot_level)
+        for table in resource.tables:
+            if not self.valid_tables_re.match(table.name):
+                self.report(resource, "Unknown table name '%s'" % table.name,
+                            table.linenumber)

--- a/rflint/rules/suiteRules.py
+++ b/rflint/rules/suiteRules.py
@@ -19,14 +19,27 @@ class PeriodInSuiteName(SuiteRule):
             self.report(suite, "'.' in suite name '%s'" % suite.name, 0)
 
 class InvalidTable(SuiteRule):
-    '''Verify that there are no invalid table headers'''
-    severity = WARNING
+    '''Verify that there are no invalid table headers
+
+    Parameter robot_level to be set to 'robot3' (default) or 'robot2'.'''
+    valid_tables_re = None
+    default_robot_level = "robot3"
+
+    def configure(self, robot_level):
+        valid_tables = ['comments?', 'settings?', 'tasks?', 'test cases?',
+                        'keywords?', 'variables?']
+        if robot_level == "robot2":
+            valid_tables += ['cases?', 'metadata', 'user keywords?']
+        self.valid_tables_re = re.compile('^(' + '|'.join(valid_tables) + ')$',
+                                          re.I)
 
     def apply(self, suite):
+        if not self.valid_tables_re:
+            self.configure(self.default_robot_level)
         for table in suite.tables:
-            if (not re.match(r'^(comments?|settings?|metadata|(test )?cases?|(user )?keywords?|variables?)$', 
-                             table.name, re.IGNORECASE)):
-                self.report(suite, "Unknown table name '%s'" % table.name, table.linenumber)
+            if not self.valid_tables_re.match(table.name):
+                self.report(suite, "Unknown table name '%s'" % table.name,
+                            table.linenumber)
 
 
 class DuplicateKeywordNames(SuiteRule):

--- a/test_data/acceptance/rules/InvalidTableInResource_Data.robot
+++ b/test_data/acceptance/rules/InvalidTableInResource_Data.robot
@@ -1,12 +1,11 @@
 ## Test data for the rule InvalidTable
 ##
 
-# these should fail the rule 
+# these should fail the rule
 
 *
 * *
 *** 
-*** Testcase ***
 * Key word
 
 # these should be valid:
@@ -22,9 +21,6 @@
 *** Comment ***
 *** Comments ***
 *** Metadata ***
-*** Cases ***
-*** Test Case ***
-*** Test Cases ***
 *** Variable ***
 *** Variables ***
 *** Keyword ***

--- a/tests/acceptance/arguments.robot
+++ b/tests/acceptance/arguments.robot
@@ -80,12 +80,12 @@
 | | [Documentation]
 | | ... | Verify that --describe works
 | | Run rf-lint with the following options:
-| | ... | --describe | InvalidTable
+| | ... | --describe | RequireKeywordDocumentation
 | | rflint return code should be | 0
 | | Stderr should be | ${EMPTY}
 | | Stdout should be
-| | ... | InvalidTable
-| | ... | ${SPACE*4}Verify that there are no invalid table headers
+| | ... | RequireKeywordDocumentation
+| | ... | ${SPACE*4}Verify that a keyword has documentation
 
 | The --describe option with invalid rule name
 | | [Documentation]

--- a/tests/acceptance/rules/InvalidTable.robot
+++ b/tests/acceptance/rules/InvalidTable.robot
@@ -7,31 +7,37 @@
 | ... | log | ${result.stdout}\n${result.stderr}
 
 *** Test Cases ***
-| Verify all invalid table names are detected
+| Verify all invalid table names in Robot 2 are detected
 | | [Documentation]
 | | ... | Verify that all invalid table names cause errors,
 | | ... | and all valid names do not. Note: the test data
 | | ... | is a collection of both valid and invalid names.
+| | ... | Robot 2 accepted a few synonyms that were deprecated
+| | ... | in Robot 3.
 | |
 | | [Setup] | Run rf-lint with the following options:
 | | ... | --no-filename
-| | ... | --ignore | all
-| | ... | --error  | InvalidTable
+| | ... | --ignore    | all
+| | ... | --error     | InvalidTable
+| | ... | --configure | InvalidTable:robot2
 | | ... | test_data/acceptance/rules/InvalidTable_Data.robot
 | |
 | | rflint return code should be | 6
 | | rflint should report 6 errors
 | | rflint should report 0 warnings
 
-| Verify that the proper error message is returned
+| Verify that the proper error message is returned with Robot 2 option
 | | [Documentation]
 | | ... | Verify that InvalidTable returns the expected message
 | | ... | for every error
+| | ... | Robot 2 accepted a few synonyms that were deprecated
+| | ... | in Robot 3.
 | |
 | | [Setup] | Run rf-lint with the following options:
 | | ... | --no-filename
-| | ... | --ignore | all
-| | ... | --error  | InvalidTable
+| | ... | --ignore    | all
+| | ... | --error     | InvalidTable
+| | ... | --configure | InvalidTable:robot2
 | | ... | test_data/acceptance/rules/InvalidTable_Data.robot
 | |
 | | Output should contain
@@ -40,4 +46,48 @@
 | | ... | E: 8, 0: Unknown table name '' (InvalidTable)
 | | ... | E: 9, 0: Unknown table name 'Testcase' (InvalidTable)
 | | ... | E: 10, 0: Unknown table name 'Key word' (InvalidTable)
-| | ... | E: 36, 0: Unknown table name 'bogus' (InvalidTable)
+| | ... | E: 37, 0: Unknown table name 'bogus' (InvalidTable)
+
+| Verify all invalid table names in Robot 3 are detected
+| | [Documentation]
+| | ... | Verify that all invalid table names cause errors,
+| | ... | and all valid names do not. Note: the test data
+| | ... | is a collection of both valid and invalid names.
+| | ... | Robot 3 obsoleted some synonyms that were valid with
+| | ... | Robot 2.
+| |
+| | [Setup] | Run rf-lint with the following options:
+| | ... | --no-filename
+| | ... | --ignore    | all
+| | ... | --error     | InvalidTable
+| | ... | --configure | InvalidTable:robot3
+| | ... | test_data/acceptance/rules/InvalidTable_Data.robot
+| |
+| | rflint return code should be | 10
+| | rflint should report 10 errors
+| | rflint should report 0 warnings
+
+| Verify that the proper error message is returned
+| | [Documentation]
+| | ... | Verify that InvalidTable returns the expected message
+| | ... | for every error, using default option (Robot 3 syntax).
+| | ... | Robot 3 obsoleted some synonyms that were valid with
+| | ... | Robot 2.
+| |
+| | [Setup] | Run rf-lint with the following options:
+| | ... | --no-filename
+| | ... | --ignore    | all
+| | ... | --error     | InvalidTable
+| | ... | test_data/acceptance/rules/InvalidTable_Data.robot
+| |
+| | Output should contain
+| | ... | E: 6, 0: Unknown table name '' (InvalidTable)
+| | ... | E: 7, 0: Unknown table name '' (InvalidTable)
+| | ... | E: 8, 0: Unknown table name '' (InvalidTable)
+| | ... | E: 9, 0: Unknown table name 'Testcase' (InvalidTable)
+| | ... | E: 10, 0: Unknown table name 'Key word' (InvalidTable)
+| | ... | E: 24, 0: Unknown table name 'Metadata' (InvalidTable)
+| | ... | E: 25, 0: Unknown table name 'Cases' (InvalidTable)
+| | ... | E: 32, 0: Unknown table name 'User Keyword' (InvalidTable)
+| | ... | E: 33, 0: Unknown table name 'User Keywords' (InvalidTable)
+| | ... | E: 37, 0: Unknown table name 'bogus' (InvalidTable)

--- a/tests/acceptance/rules/InvalidTableInResource.robot
+++ b/tests/acceptance/rules/InvalidTableInResource.robot
@@ -1,0 +1,91 @@
+*** Settings ***
+| Documentation | Tests for the rule 'InvalidTableInResource'
+| Resource      | ../SharedKeywords.robot
+|
+| Test Teardown
+| ... | Run keyword if | "${TEST STATUS}" == "FAIL"
+| ... | log | ${result.stdout}\n${result.stderr}
+
+*** Test Cases ***
+| Verify all invalid table names in Robot 2 are detected
+| | [Documentation]
+| | ... | Verify that all invalid table names in a resource
+| | ... | file cause errors, and all valid names do not.
+| | ... | Robot 2 accepted a few synonyms that were deprecated
+| | ... | in Robot 3.
+| | ... | Note: the test data is a collection of both valid
+| | ... | and invalid names.
+| |
+| | [Setup] | Run rf-lint with the following options:
+| | ... | --no-filename
+| | ... | --ignore    | all
+| | ... | --error     | InvalidTableInResource
+| | ... | --configure | InvalidTableInResource:robot2
+| | ... | test_data/acceptance/rules/InvalidTableInResource_Data.robot
+| |
+| | rflint return code should be | 5
+| | rflint should report 5 errors
+| | rflint should report 0 warnings
+
+| Verify that the proper error message is returned with Robot 2 option
+| | [Documentation]
+| | ... | Verify that InvalidTableInResource returns the
+| | ... | expected message for every error
+| | ... | Robot 2 accepted a few synonyms that were deprecated
+| | ... | in Robot 3.
+| |
+| | [Setup] | Run rf-lint with the following options:
+| | ... | --no-filename
+| | ... | --ignore    | all
+| | ... | --error     | InvalidTableInResource
+| | ... | --configure | InvalidTableInResource:robot2
+| | ... | test_data/acceptance/rules/InvalidTableInResource_Data.robot
+| |
+| | Output should contain
+| | ... | E: 6, 0: Unknown table name '' (InvalidTableInResource)
+| | ... | E: 7, 0: Unknown table name '' (InvalidTableInResource)
+| | ... | E: 8, 0: Unknown table name '' (InvalidTableInResource)
+| | ... | E: 9, 0: Unknown table name 'Key word' (InvalidTableInResource)
+| | ... | E: 33, 0: Unknown table name 'bogus' (InvalidTableInResource)
+
+| Verify all invalid table names in Robot 3 are detected
+| | [Documentation]
+| | ... | Verify that all invalid table names in a resource
+| | ... | file cause errors, and all valid names do not.
+| | ... | Robot 3 obsoleted some synonyms that were valid with
+| | ... | Robot 2.
+| | ... | Note: the test data is a collection of both valid
+| | ... | and invalid names.
+| |
+| | [Setup] | Run rf-lint with the following options:
+| | ... | --no-filename
+| | ... | --ignore    | all
+| | ... | --error     | InvalidTableInResource
+| | ... | test_data/acceptance/rules/InvalidTableInResource_Data.robot
+| |
+| | rflint return code should be | 8
+| | rflint should report 8 errors
+| | rflint should report 0 warnings
+
+| Verify that the proper error message is returned
+| | [Documentation]
+| | ... | Verify that InvalidTableInResource returns the expected message
+| | ... | for every error, using default option (Robot 3 syntax).
+| | ... | Robot 2 accepted a few synonyms that were deprecated
+| | ... | in Robot 3.
+| |
+| | [Setup] | Run rf-lint with the following options:
+| | ... | --no-filename
+| | ... | --ignore    | all
+| | ... | --error     | InvalidTableInResource
+| | ... | test_data/acceptance/rules/InvalidTableInResource_Data.robot
+| |
+| | Output should contain
+| | ... | E: 6, 0: Unknown table name '' (InvalidTableInResource)
+| | ... | E: 7, 0: Unknown table name '' (InvalidTableInResource)
+| | ... | E: 8, 0: Unknown table name '' (InvalidTableInResource)
+| | ... | E: 9, 0: Unknown table name 'Key word' (InvalidTableInResource)
+| | ... | E: 23, 0: Unknown table name 'Metadata' (InvalidTableInResource)
+| | ... | E: 28, 0: Unknown table name 'User Keyword' (InvalidTableInResource)
+| | ... | E: 29, 0: Unknown table name 'User Keywords' (InvalidTableInResource)
+| | ... | E: 33, 0: Unknown table name 'bogus' (InvalidTableInResource)


### PR DESCRIPTION
Hi Bryan,

Further to the PR that added "Comments" table; as it turned out, "Metadata", "User Keywords" and "Cases" (aliases for "Settings", "Keywords", "Test Cases") are no longer accepted in Robot 3, but were in Robot 2. Check for invalid table names in resource files too.

Also, allow a Tasks table; closes: #64.

There is a config option "--configure=InvalidTable:robot2" to accept these the Robot2 names.