### PR TITLE
Report duplicate variable definition

### DIFF
--- a/rflint/common.py
+++ b/rflint/common.py
@@ -5,6 +5,11 @@ WARNING = "W"
 IGNORE = "I"
 
 
+def normalize_name(string):
+    '''convert to lowercase, remove spaces and underscores'''
+    return string.replace(" ", "").replace("_", "").lower()
+
+
 class Rule(object): 
     # default severity; subclasses may override
     severity = WARNING

--- a/rflint/rules/duplicates.py
+++ b/rflint/rules/duplicates.py
@@ -1,0 +1,82 @@
+from rflint.common import SuiteRule, ResourceRule, ERROR, normalize_name
+
+def check_duplicates(report_duplicate, table,
+                     permitted_dups=None, normalize_itemname=normalize_name):
+    # `table` is a SettingsTable or a VariableTable; either contains rows,
+    # but only VariableTable also contains statements.
+    seen_rows = {}
+    for row in table.rows:
+        item = normalize_itemname(row[0])
+
+        # skip empty lines, comments and continuation lines
+        if item == "":
+            continue
+        if item.startswith("#"):
+            continue
+        if item.startswith("..."):
+            continue
+
+        # some tables allow duplicates
+        if permitted_dups and item in permitted_dups:
+            continue
+
+        if item in seen_rows:
+            prev_row = seen_rows[item]
+            report_duplicate(row, prev_row)
+        else:
+            seen_rows[item] = row
+
+
+class DuplicateSettingsCommon(object):
+    '''Verify that settings are not repeated in a Settings table
+
+    This has been made an error in Robot3.0
+    https://github.com/robotframework/robotframework/issues/2204'''
+    severity = ERROR
+
+    def apply(self, suite):
+        def report_duplicate_setting(setting, prev_setting):
+            self.report(suite,
+                "Setting '%s' used multiple times (previously used line %d)" % \
+                (setting[0], prev_setting.linenumber), setting.linenumber)
+
+        for table in suite.tables:
+            if table.name == "Settings":
+                check_duplicates(report_duplicate_setting, table,
+                    permitted_dups=["library", "resource", "variables"])
+
+class DuplicateSettingsInSuite(DuplicateSettingsCommon, SuiteRule):
+    pass
+
+class DuplicateSettingsInResource(DuplicateSettingsCommon, ResourceRule):
+    pass
+
+
+def strip_variable_name(varname):
+    return varname.lstrip("${").rstrip("}= ")
+
+def normalize_variable_name(varname):
+    return normalize_name(strip_variable_name(varname))
+
+class DuplicateVariablesCommon(object):
+    '''Verify that variables are not defined twice in the same table
+
+    This is not an error, but leads to surprising result (first definition
+    wins, later is ignored).'''
+    def apply(self, suite):
+        def report_duplicate_variable(variable, prev_variable):
+            self.report(suite,
+                "Variable '%s' defined twice, previous definition line %d" % \
+                (strip_variable_name(variable[0]), prev_variable.linenumber),
+                variable.linenumber)
+
+        for table in suite.tables:
+            if table.name == "Variables":
+                check_duplicates(report_duplicate_variable, table,
+                                 normalize_itemname=normalize_variable_name)
+
+class DuplicateVariablesInSuite(DuplicateVariablesCommon, SuiteRule):
+    pass
+
+class DuplicateVariablesInResource(DuplicateVariablesCommon, ResourceRule):
+    pass

--- a/rflint/rules/suiteRules.py
+++ b/rflint/rules/suiteRules.py
@@ -1,19 +1,15 @@
-from rflint.common import SuiteRule, ERROR, WARNING
+from rflint.common import SuiteRule, ERROR, WARNING, normalize_name
 from rflint.parser import SettingTable
 import re
 
-def normalize_name(string):
-    '''convert to lowercase, remove spaces and underscores'''
-    return string.replace(" ", "").replace("_", "").lower()
-
 class PeriodInSuiteName(SuiteRule):
     '''Warn about periods in the suite name
-    
+
     Since robot uses "." as a path separator, using a "." in a suite
-    name can lead to ambiguity. 
+    name can lead to ambiguity.
     '''
     severity = WARNING
-    
+
     def apply(self,suite):
         if "." in suite.name:
             self.report(suite, "'.' in suite name '%s'" % suite.name, 0)
@@ -78,16 +74,16 @@ class RequireSuiteDocumentation(SuiteRule):
                 break
 
         self.report(suite, "No suite documentation", linenum)
-            
+
 class TooManyTestCases(SuiteRule):
     '''
-    Should not have too many tests in one suite. 
+    Should not have too many tests in one suite.
 
     The exception is if they are data-driven.
 
     https://code.google.com/p/robotframework/wiki/HowToWriteGoodTestCases#Test_suite_structure
 
-    You can configure the maximum number of tests. The default is 10. 
+    You can configure the maximum number of tests. The default is 10.
     '''
     severity = WARNING
     max_allowed = 10

--- a/test_data/acceptance/rules/DuplicateSettings_Data.robot
+++ b/test_data/acceptance/rules/DuplicateSettings_Data.robot
@@ -1,0 +1,12 @@
+*** Settings ***
+Documentation    Having two documentation sections is illegal.
+                 ...    Use continuation lines for multiple lines.
+Documentation    Error here.
+
+# Several Library settings is okay
+Library    DateTime
+Library    Collections
+
+*** Test Cases ***
+Test 1
+    No operation

--- a/test_data/acceptance/rules/DuplicateVariablesInResource_Data.robot
+++ b/test_data/acceptance/rules/DuplicateVariablesInResource_Data.robot
@@ -1,0 +1,7 @@
+*** Variables ***
+${some_var}=    foo
+${some_var}=    bar
+${SomeVar}=     baz
+
+*** Keyword ***
+Keyword 1    No Operation

--- a/test_data/acceptance/rules/DuplicateVariables_Data.robot
+++ b/test_data/acceptance/rules/DuplicateVariables_Data.robot
@@ -1,0 +1,7 @@
+*** Variables ***
+${some_var}=    foo
+${some_var}=    bar
+${SomeVar}=     baz
+
+*** Test Cases ***
+Test1    No Operation

--- a/tests/acceptance/rules/DuplicateSettings.robot
+++ b/tests/acceptance/rules/DuplicateSettings.robot
@@ -1,0 +1,26 @@
+*** Settings ***
+| Documentation | Tests for the suite rule 'DuplicateSettings'
+| Resource      | ../SharedKeywords.robot
+|
+| Test Teardown
+| ... | Run keyword if | "${TEST STATUS}" == "FAIL"
+| ... | log | ${result.stdout}\n${result.stderr}
+
+*** Test Cases ***
+| Verify duplicate settings raise an error
+| | [Documentation]
+| | ... | Verify duplicate settings raise an error
+| |
+| | [Setup] | Run rf-lint with the following options:
+| | ... | --no-filename
+| | ... | --ignore | all
+| | ... | --error  | DuplicateSettingsInSuite
+| | ... | test_data/acceptance/rules/DuplicateSettings_Data.robot
+| |
+| | Stderr should be | ${EMPTY}
+| | Stdout should be
+| | ... | E: 4, 0: Setting 'Documentation' used multiple times (previously used line 2) (DuplicateSettingsInSuite)
+| |
+| | rflint return code should be | 1
+| | rflint should report 1 errors
+| | rflint should report 0 warnings

--- a/tests/acceptance/rules/DuplicateVariables.robot
+++ b/tests/acceptance/rules/DuplicateVariables.robot
@@ -1,0 +1,38 @@
+*** Settings ***
+| Documentation | Tests for the suite rule 'DuplicateVariables'
+| Resource      | ../SharedKeywords.robot
+|
+| Test Teardown
+| ... | Run keyword if | "${TEST STATUS}" == "FAIL"
+| ... | log | ${result.stdout}\n${result.stderr}
+
+*** Test Cases ***
+| Verify duplicate variable definitions raise an error
+| | [Documentation]
+| | ... | Verify duplicate variable definitions raise an error
+| |
+| | [Setup] | Run rf-lint with the following options:
+| | ... | --no-filename
+| | ... | --ignore | all
+| | ... | --error  | DuplicateVariablesInSuite
+| | ... | test_data/acceptance/rules/DuplicateVariables_Data.robot
+| |
+| | Stderr should be | ${EMPTY}
+| | Stdout should be
+| | ... | E: 3, 0: Variable 'some_var' defined twice, previous definition line 2 (DuplicateVariablesInSuite)
+| | ... | E: 4, 0: Variable 'SomeVar' defined twice, previous definition line 2 (DuplicateVariablesInSuite)
+
+| Verify duplicate variable definitions in a Resource file raise an error
+| | [Documentation]
+| | ... | Verify duplicate variable definitions in a Resource file raise an error
+| |
+| | [Setup] | Run rf-lint with the following options:
+| | ... | --no-filename
+| | ... | --ignore | all
+| | ... | --error  | DuplicateVariablesInResource
+| | ... | test_data/acceptance/rules/DuplicateVariablesInResource_Data.robot
+| |
+| | Stderr should be | ${EMPTY}
+| | Stdout should be
+| | ... | E: 3, 0: Variable 'some_var' defined twice, previous definition line 2 (DuplicateVariablesInResource)
+| | ... | E: 4, 0: Variable 'SomeVar' defined twice, previous definition line 2 (DuplicateVariablesInResource)


### PR DESCRIPTION
Hi Bryan,

This adds checking for variables defined twice (in the same table). Robot would silently ignore the second definition (or a second definition that only differ by case, whitespace or extra `_`).