### PR TITLE
allow to duplicate Metadata

### DIFF
--- a/rflint/rules/duplicates.py
+++ b/rflint/rules/duplicates.py
@@ -43,7 +43,7 @@ class DuplicateSettingsCommon(object):
         for table in suite.tables:
             if table.name == "Settings":
                 check_duplicates(report_duplicate_setting, table,
-                    permitted_dups=["library", "resource", "variables"])
+                    permitted_dups=["library", "resource", "variables", "metadata"])
 
 class DuplicateSettingsInSuite(DuplicateSettingsCommon, SuiteRule):
     pass

--- a/test_data/acceptance/rules/DuplicateSettings_Data.robot
+++ b/test_data/acceptance/rules/DuplicateSettings_Data.robot
@@ -3,6 +3,11 @@ Documentation    Having two documentation sections is illegal.
                  ...    Use continuation lines for multiple lines.
 Documentation    Error here.
 
+# Metadata can used multiple times
+Metadata    Version        2.0
+Metadata    More Info      For more information about *Robot Framework* see http://robotframework.org
+Metadata    Executed At    ${HOST}
+
 # Several Library settings is okay
 Library    DateTime
 Library    Collections


### PR DESCRIPTION
allow to duplicate Metadata sections to remove error introduced in https://github.com/boakley/robotframework-lint/pull/71

```robot
*** Settings ***
Metadata    Version        2.0
Metadata    More Info      For more information about *Robot Framework* see http://robotframework.org
Metadata    Executed At    ${HOST}
```

would generate 2 errors like:
```sh
E: 11, 0: Setting 'Metadata' used multiple times (previously used line 10) (DuplicateSettingsInSuite)
```

Fixes https://github.com/boakley/robotframework-lint/issues/78