### PR TITLE
Add filename information to format command line option

### DIFF
--- a/rflint/rflint.py
+++ b/rflint/rflint.py
@@ -257,7 +257,7 @@ class RfLint(object):
                 "rules except DuplicateTestNames.\n"
                 "\n"
                 "FORMAT is a string that performs a substitution on the following \n"
-                "patterns: {severity}, {linenumber}, {char}, {message}, and {rulename}.\n"
+                "patterns: {filename}, {severity}, {linenumber}, {char}, {message} and {rulename}.\n"
                 "\n"
                 "For example: --format 'line: {linenumber}: message: {message}'. \n"
                 "\n"


### PR DESCRIPTION
There is a possibility to include file path in issues reported in output. Special FORMAT option can handle the appearance of the results and it already has a possibility to display path to the file but it's not documented in the help info. This Pull Request adds this info to the help message.

I find it very useful, because that way I can imitate the output to be similar with the pylint, thus I can take advantage of the _Output filters_ feature in _External tools_ in PyCharm as well as parse the output easier when integrating RFLint with CI&CD tools.