### PR TITLE
Add command line option to display summary of issues

### DIFF
--- a/rflint/rflint.py
+++ b/rflint/rflint.py
@@ -100,7 +100,7 @@ class RfLint(object):
             self._describe_rules(self.args.args)
             return 0
 
-        self.counts = { ERROR: 0, WARNING: 0, "other": 0}
+        self.counts = {ERROR: 0, WARNING: 0, "other": 0}
 
         for filename in self.args.args:
             if not (os.path.exists(filename)):
@@ -110,6 +110,12 @@ class RfLint(object):
                 self._process_folder(filename)
             else:
                 self._process_file(filename)
+
+        if self.args.summary:
+            print("----------------------------------------------------------------------",
+                  f"Found {sum([x for x in self.counts.values()])} issues: "
+                  f"{self.counts['E']} ERROR(s), {self.counts['W']} WARNING(s), {self.counts['other']} other(s).",
+                  sep="\n")
 
         if self.counts[ERROR] > 0:
             return self.counts[ERROR] if self.counts[ERROR] < 254 else 255
@@ -290,6 +296,8 @@ class RfLint(object):
                             help="Display version number and exit")
         parser.add_argument("--verbose", "-v", action="store_true", default=False,
                             help="Give verbose output")
+        parser.add_argument("--summary", "-s", action="store_true", default=False,
+                            help="Show summary for found issues at the end")
         parser.add_argument("--configure", "-c", action=ConfigureAction,
                             help="Configure a rule")
         parser.add_argument("--recursive", "-r", action="store_true", default=False,

--- a/rflint/rflint.py
+++ b/rflint/rflint.py
@@ -113,7 +113,7 @@ class RfLint(object):
 
         if self.args.summary:
             print("----------------------------------------------------------------------",
-                  f"Found {sum([x for x in self.counts.values()])} issues: "
+                  f"Found {sum(self.counts.values())} issues: "
                   f"{self.counts['E']} ERROR(s), {self.counts['W']} WARNING(s), {self.counts['other']} other(s).",
                   sep="\n")
 


### PR DESCRIPTION
A new command line flag that displays the summary of RFLint execution - a sum of all found issues with information about the number of issues with specific severity. By adding -s or --summmary option to the run command, RFLint will display the info.

Example:
![image](https://user-images.githubusercontent.com/7412964/86292515-2f1a8100-bbf1-11ea-88d1-560134a8bb5d.png)
