### PR TITLE
Add file type option which ignores file extensions other than provided

### DIFF
--- a/test_data/acceptance/filetypes/test.resource
+++ b/test_data/acceptance/filetypes/test.resource
@@ -1,0 +1,2 @@
+* Invalid
+

--- a/test_data/acceptance/filetypes/test.robot
+++ b/test_data/acceptance/filetypes/test.robot
@@ -1,0 +1,3 @@
+*** Test Cases ***
+Simple Test Case
+    Pass Execution      Everything's fine

--- a/test_data/acceptance/filetypes/test.tsv
+++ b/test_data/acceptance/filetypes/test.tsv
@@ -1,0 +1,3 @@
+*** Test Cases ***
+Simple Test Case
+    Pass Execution      Everything's fine

--- a/test_data/acceptance/filetypes/test.txt
+++ b/test_data/acceptance/filetypes/test.txt
@@ -1,0 +1,3 @@
+*** Test Cases ***
+Simple Test Case
+    Pass Execution      Everything's fine

--- a/tests/acceptance/filetypes.robot
+++ b/tests/acceptance/filetypes.robot
@@ -1,0 +1,104 @@
+*** Settings ***
+Documentation   Check if rflint reads supported file formats
+Library         OperatingSystem
+Library         Process
+Library         String
+Resource        SharedKeywords.robot
+
+
+*** Test Cases ***
+All Supported File Types
+    [Template]      Run Rflint And Verify There Are No Errors For Supported File Types
+    robot   resource    tsv
+
+.robot And .resource Supported File Types
+    [Template]      Run Rflint And Verify There Are No Errors For Supported File Types
+    robot   resource
+
+.resource And .tsv Supported File Types
+    [Template]      Run Rflint And Verify There Are No Errors For Supported File Types
+            resource    tsv
+
+.robot And .tsv Supported File Types
+    [Template]      Run Rflint And Verify There Are No Errors For Supported File Types
+    robot               tsv
+
+Only .robot Supported File Type
+    [Template]      Run Rflint And Verify There Are No Errors For Supported File Types
+    robot
+
+Only .resource Supported File Type
+    [Template]      Run Rflint And Verify There Are No Errors For Supported File Types
+            resource
+
+Only .tsv Supported File Type
+    [Template]      Run Rflint And Verify There Are No Errors For Supported File Types
+                        tsv
+
+Only .pdf Unsupported File Type
+    [Template]      Run Rflint And Verify That Unsupported File Types Returned Errors
+    pdf
+
+Specific .txt File With .robot Provided File Type
+    [Template]      Run Rflint And Verify There Are No Output For Not Matching File Types
+    test_data/acceptance/filetypes/test.txt         robot
+
+Specific .robot File With .resource Provided File Type
+    [Template]      Run Rflint And Verify There Are No Output For Not Matching File Types
+    test_data/acceptance/filetypes/test.robot       resource
+
+Specific .resource File With .robot And .tsv Provided File Type
+    [Template]      Run Rflint And Verify There Are No Output For Not Matching File Types
+    test_data/acceptance/filetypes/test.resource    robot   tsv
+
+Specific .tsv File With .robot And .resource Provided File Type
+    [Template]      Run Rflint And Verify There Are No Output For Not Matching File Types
+    test_data/acceptance/filetypes/test.tsv         robot   resource
+
+
+*** Keywords ***
+Run Rflint And Verify There Are No Errors For Supported File Types
+    [Arguments]                 @{extensions}
+    ${file_types}               Parse File Types    @{extensions}
+    Run rf-lint with the following options:
+    ...     --filetypes         ${file_types}
+    ...     test_data/acceptance/filetypes
+    FOR     ${file_type}   IN   @{extensions}
+            Should Contain      ${result.stdout}    test.${file_type}
+    END
+    Should Be Empty             ${result.stderr}
+
+Run Rflint And Verify That Unsupported File Types Returned Errors
+    [Arguments]                 @{extensions}
+    ${file_types}               Parse File Types    @{extensions}
+    Run rf-lint with the following options:
+    ...     --filetypes         ${file_types}
+    ...     test_data/acceptance/filetypes
+    FOR     ${file_type}   IN   @{extensions}
+            Should Contain      ${result.stderr}    rflint: File extension .${file_type} is not supported
+    END
+    Should Be Empty             ${result.stdout}
+
+Run Rflint And Verify There Are No Output For Not Matching File Types
+    [Arguments]                 ${path_to_file}     @{extensions}
+    ${file_types}               Parse File Types    @{extensions}
+    Run rf-lint with the following options:
+    ...     -t                 ${file_types}
+    ...     ${path_to_file}
+    FOR     ${file_type}   IN   @{extensions}
+            Should Be Empty     ${result.stdout}    ${EMPTY}
+            Should Be Empty     ${result.stderr}    ${EMPTY}
+    END
+    Should Be Empty             ${result.stderr}
+
+Parse File Types
+    [Arguments]         @{filetypes}
+    ${types}            Set Variable    ${EMPTY}
+    FOR     ${index}    ${file_type}    IN ENUMERATE     @{filetypes}
+        ${types}        Run Keyword If  ${index}==${0}
+        ...             Set Variable    ${file_type}
+        ...             ELSE
+        ...             Set Variable    ${types},${file_type}
+    END
+    Log                 Provided filetypes: ${types}
+    [Return]            ${types}


### PR DESCRIPTION
Currently RFlint operates on .robot, .resource, .txt and .tsv file extensions but in RF 3.2 all extensions different than .robot and .resource. are not automatically supported (you need to provide them explicitly). There is also a file type .rst that RF supports but RFLint does not read it. By adding new command line option the user is able to select which file types will be processed and RFlint will ignore the others. The default supported files are .robot and .resource but you can also provide .txt, .tsv and .rst extensions.

The option is called by --filetypes or -t with extensions separated by comma, e.g. rflint -t robot,resource,txt

I added also test cases to cover this new feature.