### PR TITLE
Add requirement limitation in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     long_description = open('README.md').read(),
     zip_safe         = False,
     include_package_data = True,
-    install_requires = ['robotframework'],
+    install_requires = ['robotframework>=3.2'],
     classifiers      = [
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: Apache Software License",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     long_description = open('README.md').read(),
     zip_safe         = False,
     include_package_data = True,
-    install_requires = ['robotframework>=3.2'],
+    install_requires = ['robotframework>=3.2.1'],
     classifiers      = [
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
I try to add the limitation of robotframework in setup.py.
It helps pip to get the right dependency, and it will avoid #76 issue